### PR TITLE
fix device issue in set_duration

### DIFF
--- a/mp_pytorch/mp/mp_interfaces.py
+++ b/mp_pytorch/mp/mp_interfaces.py
@@ -167,7 +167,7 @@ class MPInterface(ABC):
             duration = round(self.tau.max().item() / dt) * dt
 
         # dt = torch.as_tensor(dt, dtype=self.dtype, device=self.device)
-        times = torch.linspace(0, duration, round(duration / dt) + 1)
+        times = torch.linspace(0, duration, round(duration / dt) + 1, dtype=self.dtype, device=self.device)
         times = util.add_expand_dim(times, list(range(len(self.add_dim))),
                                     self.add_dim)
 


### PR DESCRIPTION
### All Submissions:

* [x] ❗ Have you successfully run the demos for **ALL** MPs ??
* [x] Note in your description if the branch should **not** be deleted. Branches will be deleted after a successfull merge by default.


### Description
This fixes a bug with the device in the `set_duration` method of the `MPInterface`. The last assertion of the test for ProDMPs fails, but I doubt that this is somehow related.
